### PR TITLE
Django 2 compatibility

### DIFF
--- a/aldryn_search/views.py
+++ b/aldryn_search/views.py
@@ -61,7 +61,7 @@ class AldrynSearchView(FormMixin, ListView):
 
     def get_queryset(self):
         queryset = self.form.search()
-        if not self.request.user.is_authenticated():
+        if not self.request.user.is_authenticated:
             queryset = queryset.exclude(login_required=True)
         # TODO: fix that url filter.
         # url__in=['', None] make the query exclude "" and "None".


### PR DESCRIPTION
`user.is_authenticated` is a property from Django 1.10 upwards, support for calling it as a method was removed in Django 2.0.

This pull request is incompatible with Django<1.10, which shouldn't be a problem since Django<1.11 is now unsupported anyway (might still be worth a note/dependency?).