### PR TITLE
Added Django 2.2 and DjangoCMS 3.7 test configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
     # Django 2.1
     - python: 3.6
       env: DJANGO='dj21' CMS='cms36'
+    # Django 2.2
+    - python: 3.6
+      env: DJANGO='dj22' CMS='cms37'
 
 install:
   - pip install coverage tox

--- a/aldryn_search/compat.py
+++ b/aldryn_search/compat.py
@@ -2,6 +2,7 @@ from distutils.version import LooseVersion
 
 import cms
 
+
 GTE_CMS_35 = LooseVersion(cms.__version__) >= LooseVersion('3.5')
 
 

--- a/aldryn_search/views.py
+++ b/aldryn_search/views.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from aldryn_common.paginator import DiggPaginator
 from django.utils.translation import get_language_from_request
 from django.views.generic import ListView
 from django.views.generic.edit import FormMixin
+
+from aldryn_common.paginator import DiggPaginator
 from haystack.forms import ModelSearchForm
 from haystack.query import SearchQuerySet
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,10 @@
 envlist =
     flake8
     isort
-    py{27,34,35,36}-dj111-cms{34,35,36}
-    py{34,35,36,37}-dj20-cms36
-    py{35,36,37}-dj21-cms36
+    py{27,34,35,36}-dj111-cms{34,35,36,37}
+    py{34,35,36,37}-dj20-cms{36,37}
+    py{35,36,37}-dj21-cms{36,37}
+    py{35,36,37}-dj22-cms37
 
 skip_missing_interpreters=True
 
@@ -44,10 +45,14 @@ deps =
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
+    dj22: Django>=2.2,<2.3
 
     cms34: django-cms>=3.4,<3.5
     cms35: django-cms>=3.5,<3.6
     cms36: django-cms>=3.6,<3.7
+    cms37: django-cms>=3.7,<3.8
+
+    py34: lxml<4.4 #lxml 4.4 dropped py34 support
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
I noticed that there is an unreleased commit which adds Django 2.2 support. It however currently fails isort validation on the CI. This is a commit to try and address that, in the hope that there will soon be an official version bump (See issue #102), especially because django-cms 3.7 is now out and encourages people to use Django 2.2.