### PR TITLE
Bumped version to 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 
+dist: xenial
 sudo: false
 
 matrix:
@@ -15,14 +16,17 @@ matrix:
       env: DJANGO='dj111' CMS='cms35'
     - python: 3.5
       env: DJANGO='dj111' CMS='cms36'
-    # Django 2.0
-    - python: 3.5
-      env: DJANGO='dj20' CMS='cms36'
+    - python: 3.6
+      env: DJANGO='dj111' CMS='cms37'
     # Django 2.1
     - python: 3.6
       env: DJANGO='dj21' CMS='cms36'
+    - python: 3.6
+      env: DJANGO='dj21' CMS='cms37'
     # Django 2.2
     - python: 3.6
+      env: DJANGO='dj22' CMS='cms37'
+    - python: 3.7
       env: DJANGO='dj22' CMS='cms37'
 
 install:
@@ -31,6 +35,7 @@ install:
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then export PY_VER=py34; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PY_VER=py35; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PY_VER=py36; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then export PY_VER=py37; fi"
   - "if [[ ${DJANGO}z != 'z' ]]; then export TOX_ENV=$PY_VER-$DJANGO-$CMS; fi"
 
 script:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,11 +3,13 @@ Changelog
 =========
 
 
-1.1.0 (unreleased)
+1.1.0 (2020-02-20)
 ==================
 
+* Added support for Django 2.2 and django CMS 3.7
 * Added support for Transifex
 * Added isort and flake8
+* Changed from djangocms-helper to django-app-helper
 * Extended test matrix
 * Adapted code base to align with other supported addons
 * Removed ``INDEX_TITLE`` backwards compatibility shim

--- a/aldryn_search/__init__.py
+++ b/aldryn_search/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 
 default_app_config = 'aldryn_search.apps.AldrynSearchConfig'

--- a/test
+++ b/test
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-djangocms-helper aldryn_search --cms test --extra-settings=tests/settings $@
+django-app-helper aldryn_search --cms test --extra-settings=tests/settings $@

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,4 +2,7 @@ coverage
 pysolr
 djangocms-admin-style
 django-appconf
-djangocms-helper>=1.1.0
+django-app-helper>=1.1.0
+six
+isort
+flake8

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -70,7 +70,7 @@ HELPER_SETTINGS = {
 
 
 def run():
-    from djangocms_helper import runner
+    from app_helper import runner
     runner.cms('aldryn_search')
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -3,8 +3,9 @@
 # http://tech.octopus.energy/news/2016/01/21/testing-for-missing-migrations-in-django.html
 from django.core.management import call_command
 from django.test import TestCase, override_settings
-from django.utils.six import text_type
-from django.utils.six.moves import StringIO
+
+from six import text_type
+from six.moves import StringIO
 
 
 class MigrationTestCase(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,9 @@
 envlist =
     flake8
     isort
-    py{27,34,35,36}-dj111-cms{34,35,36,37}
-    py{34,35,36,37}-dj20-cms{36,37}
-    py{35,36,37}-dj21-cms{36,37}
-    py{35,36,37}-dj22-cms37
+    py{27,34,35,36}-dj111-cms{34,35,36}
+    py{27,35,36}-dj111-cms37
+    py{35,36,37}-dj{21,22}-cms{36,37}
 
 skip_missing_interpreters=True
 
@@ -43,26 +42,22 @@ known_django = django
 deps =
     -r{toxinidir}/tests/requirements.txt
     dj111: Django>=1.11,<2.0
-    dj20: Django>=2.0,<2.1
+    dj111: django-formtools>=2.0,<2.1
     dj21: Django>=2.1,<2.2
-    dj22: Django>=2.2,<2.3
-
+    dj22: Django>=2.2,<3.0
     cms34: django-cms>=3.4,<3.5
     cms35: django-cms>=3.5,<3.6
     cms36: django-cms>=3.6,<3.7
     cms37: django-cms>=3.7,<3.8
-
-    py34: lxml<4.4 #lxml 4.4 dropped py34 support
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase
-    {env:COMMAND:coverage} run tests/settings.py
+    {env:COMMAND:coverage} run setup.py test
     {env:COMMAND:coverage} report
 
 [testenv:flake8]
 deps = flake8
 commands = flake8
-basepython = python3.5
 
 [testenv:isort]
 deps = isort

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,7 @@ deps =
     cms35: django-cms>=3.5,<3.6
     cms36: django-cms>=3.6,<3.7
     cms37: django-cms>=3.7,<3.8
+    py35: lxml<4.4
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     cms35: django-cms>=3.5,<3.6
     cms36: django-cms>=3.6,<3.7
     cms37: django-cms>=3.7,<3.8
-    py35: lxml<4.4
+    py34: lxml<4.4
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
* Added support for Django 2.2 and django CMS 3.7
* Added support for Transifex
* Added isort and flake8
* Changed from djangocms-helper to django-app-helper
* Extended test matrix
* Adapted code base to align with other supported addons
* Removed ``INDEX_TITLE`` backwards compatibility shim